### PR TITLE
Move tagged union explanation

### DIFF
--- a/semantics-ex1.tex
+++ b/semantics-ex1.tex
@@ -174,6 +174,7 @@ We define the semantics of this language \emph{denotationally}. That is, instead
 \end{array}\right.
 \end{array}
 \end{displaymath}
+Note that the codomain of $~\denote{\cdot}~$ (\emph{i.e.} the set of values) is $(\mathbb{N} + \mathbb{B})_{\bot}$. $\mathbb{N} + \mathbb{B}$ represents a \emph{tagged union}.
 The subscript $\bot$ indicates that the set is ``lifted''. This simply means that we include $\bot$ (read as \emph{bottom} or \emph{undefined}) in the set. Therefore, we have:
 \begin{displaymath}
 (\mathbb{N} + \mathbb{B})_{\bot} = \set{\bot, \mathbf{inl}~0,\mathbf{inl}~1, \ldots, \mathbf{inr}~\mathit{true}, \mathbf{inr}~\mathit{false}}


### PR DESCRIPTION
Move explanation of tagged union above the language semantics to prevent confusion when reading the language semantics.
